### PR TITLE
fix URL / String bug

### DIFF
--- a/lib/deps/path/posix.ts
+++ b/lib/deps/path/posix.ts
@@ -430,5 +430,8 @@ export function parse(path: string): ParsedPath {
  * are ignored.
  */
 export function fromFileUrl(url: string | URL): string {
-  return new URL(url).pathname;
+  if (typeof url === "string")
+    url = new URL(url);
+
+  return url.pathname
 }

--- a/lib/deps/path/win32.ts
+++ b/lib/deps/path/win32.ts
@@ -908,7 +908,10 @@ export function parse(path: string): ParsedPath {
  * are ignored.
  */
 export function fromFileUrl(url: string | URL): string {
-  return new URL(url).pathname
+  if (typeof url === "string")
+    url = new URL(url);
+
+  return url.pathname
     .replace(/^\/*([A-Za-z]:)(\/|$)/, "$1/")
     .replace(/\//g, "\\");
 }


### PR DESCRIPTION
error: TS2345 [ERROR]: Argument of type 'string | URL' is not assignable to parameter of type 'string'.
  Type 'URL' is not assignable to type 'string'.
  return new URL(url).pathname
                 ~~~
    at https://deno.land/x/dex/lib/deps/path/win32.ts:911:18

TS2345 [ERROR]: Argument of type 'string | URL' is not assignable to parameter of type 'string'.
  Type 'URL' is not assignable to type 'string'.
  return new URL(url).pathname;
                 ~~~
    at https://deno.land/x/dex/lib/deps/path/posix.ts:433:18

Found 2 errors.



________

this is error fixed